### PR TITLE
Darkened the danger color of button to increase contrast with text color

### DIFF
--- a/mayan/apps/appearance/static/appearance/css/base.css
+++ b/mayan/apps/appearance/static/appearance/css/base.css
@@ -397,6 +397,10 @@ a i {
     color: #d9534f;
 }
 
+.btn-danger {
+    background-color: #730e0b;
+}
+
 .btn-default.btn-outline:hover,
 .btn-primary.btn-outline:hover,
 .btn-success.btn-outline:hover,


### PR DESCRIPTION
Resolves #1 

The background color of btn-danger used for the Actions dropdown menu on the Documents > Trash can page was darkened (from d9534f to 730e0b) to increase the contrast with the text color. This improves the Accessibility score from 82 to 84.