### PR TITLE
Deferred non-critical CSS

### DIFF
--- a/mayan/apps/appearance/templates/appearance/base_plain.html
+++ b/mayan/apps/appearance/templates/appearance/base_plain.html
@@ -19,9 +19,14 @@
             {% endblock base_title %}
         </title>
 
-        <link href="{% static 'appearance/node_modules/@fortawesome/fontawesome-free/css/all.min.css' %}" media="screen" rel="stylesheet" type="text/css" />
-        <link href="{% static 'appearance/node_modules/bootswatch/flatly/bootstrap.min.css' %}" media="screen" rel="stylesheet" type="text/css" />
-        <link href="{% static 'appearance/css/base.css' %}" media="screen" rel="stylesheet" type="text/css" />
+        <link rel="preload" href="{% static 'appearance/node_modules/@fortawesome/fontawesome-free/css/all.min.css' %}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+        <noscript><link rel="stylesheet" href="{% static 'appearance/node_modules/@fortawesome/fontawesome-free/css/all.min.css' %}"></noscript>
+
+        <link rel="preload" href="{% static 'appearance/node_modules/bootswatch/flatly/bootstrap.min.css' %}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+        <noscript><link rel="stylesheet" href="{% static 'appearance/node_modules/bootswatch/flatly/bootstrap.min.css' %}"></noscript>
+
+        <link rel="preload" href="{% static 'appearance/css/base.css' %}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+        <noscript><link rel="stylesheet" href="{% static 'appearance/css/base.css'}"></noscript>
         {% block stylesheets %}{% endblock %}
 
         <style>

--- a/mayan/apps/appearance/templates/appearance/root.html
+++ b/mayan/apps/appearance/templates/appearance/root.html
@@ -19,12 +19,24 @@
             {% endblock base_title %}
         </title>
 
-        <link href="{% static 'appearance/node_modules/@fortawesome/fontawesome-free/css/all.min.css' %}" media="screen" rel="stylesheet" type="text/css" />
-        <link href="{% static 'appearance/node_modules/bootswatch/flatly/bootstrap.min.css' %}" media="screen" rel="stylesheet" type="text/css" />
-        <link href="{% static 'appearance/node_modules/@fancyapps/fancybox/dist/jquery.fancybox.min.css' %}" media="screen" rel="stylesheet" type="text/css" />
-        <link href="{% static 'appearance/node_modules/select2/dist/css/select2.min.css' %}" media="screen" rel="stylesheet" type="text/css" />
-        <link href="{% static 'appearance/node_modules/toastr/build/toastr.min.css' %}" media="screen" rel="stylesheet" type="text/css" />
-        <link href="{% static 'appearance/css/base.css' %}" media="screen" rel="stylesheet" type="text/css" />
+        <link rel="preload" href="{% static 'appearance/node_modules/@fortawesome/fontawesome-free/css/all.min.css' %}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+        <noscript><link rel="stylesheet" href="{% static 'appearance/node_modules/@fortawesome/fontawesome-free/css/all.min.css' %}"></noscript>
+
+        <link rel="preload" href="{% static 'appearance/node_modules/bootswatch/flatly/bootstrap.min.css' %}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+        <noscript><link rel="stylesheet" href="{% static 'appearance/node_modules/bootswatch/flatly/bootstrap.min.css' %}"></noscript>
+
+        <link rel="preload" href="{% static 'appearance/node_modules/@fancyapps/fancybox/dist/jquery.fancybox.min.css' %}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+        <noscript><link rel="stylesheet" href="{% static 'appearance/node_modules/@fancyapps/fancybox/dist/jquery.fancybox.min.css' %}"></noscript>
+
+        <link rel="preload" href="{% static 'appearance/node_modules/select2/dist/css/select2.min.css' %}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+        <noscript><link rel="stylesheet" href="{% static 'appearance/node_modules/select2/dist/css/select2.min.css'}"></noscript>
+
+        <link rel="preload" href="{% static 'appearance/node_modules/toastr/build/toastr.min.cs' %}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+        <noscript><link rel="stylesheet" href="{% static 'appearance/node_modules/toastr/build/toastr.min.cs'}"></head>noscript>
+
+        <link rel="preload" href="{% static 'appearance/css/base.css' %}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+        <noscript><link rel="stylesheet" href="{% static 'appearance/css/base.css'}"></noscript>
+        
         <style id="style-javascript"></style>
         {% appearance_app_templates template_name='head' %}
         {% block stylesheets %}{% endblock %}


### PR DESCRIPTION
Resolves [Issue #7](https://github.com/CMU-313/fall-2021-hw2-crabs-adjust-humidity/issues/7). 

**Description**
As described [here](https://web.dev/render-blocking-resources/?utm_source=lighthouse&utm_medium=devtools), render-blocking stylesheets can be loaded asynchronously using the `preload` link. For our purposes, non-critical CSS is defined as files with no or nearly no coverage. 

In this PR, I have tackled the following saving opportunities by requesting an asynchronous load for each of the files below as outlined in this [tutorial](https://web.dev/defer-non-critical-css/).
<img src="https://user-images.githubusercontent.com/66378466/132247431-bdb8ceb7-3d95-4f90-90a7-f849cc7773e8.png" width="50%" height= "50%"/>

**Outcome**
At 1:07:35 PM on 9/6/2021, the Lighthouse metrics were as follows:
<img src="https://user-images.githubusercontent.com/66378466/132247921-ef628f35-560e-46fc-b2eb-5750173474a9.png" width="50%" height= "50%"/>

The score has jumped from **53** previously to **65** which is a 12 point jump. This is primarily because the first contentful paint time has been significantly reduced.

Lastly, the targeted warning has been handled because it no longer shows up as an opportunity to save under Performance.
<img src="https://user-images.githubusercontent.com/66378466/132248013-9f17561c-8b69-48f7-ae75-fd3ede03c52e.png" width="50%" height= "50%"/>