### PR TITLE
Reviewer Management widget on main dashboard to view all documents

### DIFF
--- a/mayan/apps/documents/apps.py
+++ b/mayan/apps/documents/apps.py
@@ -82,7 +82,7 @@ from .links.document_links import (
     link_document_type_change, link_document_properties_edit,
     link_document_list, link_document_recently_accessed_list,
     link_document_recently_created_list, link_document_multiple_type_change,
-    link_document_preview, link_document_properties
+    link_document_preview, link_document_properties, link_document_reviewer_management
 )
 from .links.document_file_links import (
     link_document_file_delete, link_document_file_delete_multiple,
@@ -705,7 +705,7 @@ class DocumentsApp(MayanAppConfig):
             )
         )
 
-        menu_main.bind_links(links=(menu_documents,), position=0)
+        menu_main.bind_links(links=(link_document_reviewer_management, menu_documents,), position=0)
 
         menu_setup.bind_links(links=(link_document_type_setup,))
 

--- a/mayan/apps/documents/apps.py
+++ b/mayan/apps/documents/apps.py
@@ -37,7 +37,7 @@ from .dashboard_widgets import (
     DashboardWidgetDocumentFilePagesTotal, DashboardWidgetDocumentsInTrash,
     DashboardWidgetDocumentsNewThisMonth,
     DashboardWidgetDocumentsPagesNewThisMonth, DashboardWidgetDocumentsTotal,
-    DashboardWidgetDocumentsTypesTotal,
+    DashboardWidgetDocumentsTypesTotal, DashboardWidgetReviewerManagement,
 )
 
 # Documents
@@ -691,6 +691,10 @@ class DocumentsApp(MayanAppConfig):
         )
         dashboard_main.add_widget(
             widget=DashboardWidgetDocumentsPagesNewThisMonth, order=5
+        )
+
+        dashboard_main.add_widget(
+            widget=DashboardWidgetReviewerManagement, order=6
         )
 
         menu_documents.bind_links(

--- a/mayan/apps/documents/dashboard_widgets.py
+++ b/mayan/apps/documents/dashboard_widgets.py
@@ -8,7 +8,7 @@ from mayan.apps.mayan_statistics.icons import icon_statistics
 from .icons import (
     icon_dashboard_documents_in_trash, icon_dashboard_document_types,
     icon_dashboard_pages_per_month, icon_dashboard_new_documents_this_month,
-    icon_dashboard_total_document
+    icon_dashboard_total_document, icon_document_edit
 )
 from .permissions import (
     permission_document_view, permission_document_type_view
@@ -34,6 +34,25 @@ class DashboardWidgetDocumentFilePagesTotal(DashboardWidgetNumeric):
         )
         DocumentFilePage = apps.get_model(
             app_label='documents', model_name='DocumentFilePage'
+        )
+        self.count = AccessControlList.objects.restrict_queryset(
+            permission=permission_document_view, user=request.user,
+            queryset=DocumentFilePage.valid.all()
+        ).count()
+        return super().render(request)
+
+class DashboardWidgetReviewerManagement(DashboardWidgetNumeric):
+    icon = icon_document_edit
+    label = _('Reviewer Management')
+    link = reverse_lazy(viewname='documents:document_list')
+    link_icon = icon_statistics
+
+    def render(self, request):
+        AccessControlList = apps.get_model(
+            app_label='acls', model_name='AccessControlList'
+        )
+        DocumentFilePage = apps.get_model(
+            app_label='documents', model_name='Document'
         )
         self.count = AccessControlList.objects.restrict_queryset(
             permission=permission_document_view, user=request.user,

--- a/mayan/apps/documents/dashboard_widgets.py
+++ b/mayan/apps/documents/dashboard_widgets.py
@@ -44,7 +44,7 @@ class DashboardWidgetDocumentFilePagesTotal(DashboardWidgetNumeric):
 class DashboardWidgetReviewerManagement(DashboardWidgetNumeric):
     icon = icon_document_edit
     label = _('Reviewer Management')
-    link = reverse_lazy(viewname='documents:document_list')
+    link = reverse_lazy(viewname='documents:reviewer_management')
     link_icon = icon_statistics
 
     def render(self, request):

--- a/mayan/apps/documents/links/document_links.py
+++ b/mayan/apps/documents/links/document_links.py
@@ -21,6 +21,10 @@ link_document_list = Link(
     icon=icon_document_list,
     text=_('All documents'), view='documents:document_list'
 )
+link_document_reviewer_management = Link(
+    icon=icon_document_edit,
+    text=_('Reviewer management'), view='documents:reviewer_management'
+)
 link_document_recently_accessed_list = Link(
     icon=icon_document_recently_accessed_list, text=_('Recently accessed'),
     view='documents:document_recently_accessed_list'

--- a/mayan/apps/documents/urls.py
+++ b/mayan/apps/documents/urls.py
@@ -1,3 +1,4 @@
+from mayan.apps.documents.views.reviewer_management_views import ReviewerManagementView
 from django.conf.urls import url
 
 from .api_views.document_api_views import (
@@ -442,6 +443,11 @@ urlpatterns_documents = [
         regex=r'^documents/multiple/type/$',
         name='document_multiple_type_change',
         view=DocumentTypeChangeView.as_view()
+    ),
+    url(
+        regex=r'^documents/reviewer/management/$',
+        name='reviewer_management',
+        view=ReviewerManagementView.as_view()
     ),
 ]
 

--- a/mayan/apps/documents/views/reviewer_management_views.py
+++ b/mayan/apps/documents/views/reviewer_management_views.py
@@ -1,0 +1,68 @@
+import logging
+
+from django.contrib import messages
+from django.urls import reverse
+from django.utils.translation import ugettext_lazy as _, ungettext
+
+from mayan.apps.common.classes import ModelQueryFields
+from mayan.apps.views.generics import (
+    MultipleObjectFormActionView, SingleObjectDetailView,
+    SingleObjectEditView, SingleObjectListView
+)
+
+from ..events import event_document_viewed
+from ..forms.document_forms import DocumentForm, DocumentPropertiesForm
+from ..forms.document_type_forms import DocumentTypeFilteredSelectForm
+from ..icons import icon_document_list
+from ..models.document_models import Document
+from ..permissions import (
+    permission_document_properties_edit, permission_document_view
+)
+
+from .document_version_views import DocumentVersionPreviewView
+
+__all__ = (
+    'ReviewerManagementView'
+)
+logger = logging.getLogger(name=__name__)
+
+
+class ReviewerManagementView(SingleObjectListView):
+    object_permission = permission_document_view
+
+    def get_context_data(self, **kwargs):
+        try:
+            return super().get_context_data(**kwargs)
+        except Exception as exception:
+            messages.error(
+                message=_(
+                    'Error retrieving document list: %(exception)s.'
+                ) % {
+                    'exception': exception
+                }, request=self.request
+            )
+            self.object_list = Document.valid.none()
+            return super().get_context_data(**kwargs)
+
+    def get_document_queryset(self):
+        return Document.valid.all()
+
+    def get_extra_context(self):
+        return {
+            'hide_links': True,
+            'hide_object': True,
+            'list_as_items': True,
+            'no_results_icon': icon_document_list,
+            'no_results_text': _(
+                'This could mean that no documents have been uploaded or '
+                'that your user account has not been granted the view '
+                'permission for any document or document type.'
+            ),
+            'no_results_title': _('No documents available'),
+            'title': _('Reviewer Management'),
+        }
+
+    def get_source_queryset(self):
+        queryset = ModelQueryFields.get(model=Document).get_queryset()
+        return self.get_document_queryset().filter(pk__in=queryset)
+


### PR DESCRIPTION
Resolves #12 and resolves #16 

**Description**
This PR adds a frontend view so that managers can navigate to the page to manage reviewers.

**Code Changes**
Created a new view to render the new reviewer management page in `mayan/apps/documents/views/reviewer_management_views.py`, linked the reviewer management page's url to the view in `mayan/apps/documents/urls.py`. Created new links to the new widget and the new page.

**Testing**
Open mayan and login with the admin account, and there should be a new widget on the dashboard named "Reviewer management". Clicking on the widget should bring you to a new page where you can manage reviewers for existing documents. All documents that are not in the trash can should appear on this page.

**Dependencies**
NA

**Next Steps**
Implement a dropdown list for each document to select users, and make sure the selections are saved.