### PR TITLE
Populate reviewer drop-down list with existing users

### DIFF
--- a/mayan/apps/appearance/static/appearance/css/base.css
+++ b/mayan/apps/appearance/static/appearance/css/base.css
@@ -397,10 +397,6 @@ a i {
     color: #d9534f;
 }
 
-.btn-danger {
-    background-color: #730e0b;
-}
-
 .btn-default.btn-outline:hover,
 .btn-primary.btn-outline:hover,
 .btn-success.btn-outline:hover,

--- a/mayan/apps/appearance/templates/appearance/generic_list_items_dropdown_subtemplate.html
+++ b/mayan/apps/appearance/templates/appearance/generic_list_items_dropdown_subtemplate.html
@@ -41,7 +41,7 @@
                                                     <select>
                                                         <option value="" selected>Please select a Reviewer</option>
                                                         {% for user in users %}
-                                                        <option value="{{ user.username }}">{{ user.username }}</option>
+                                                        <option value="{{ user.username }}" style="color: black">{{ user.username }}</option>
                                                         {% endfor %}
                                                     </select>
                                                 </span>

--- a/mayan/apps/appearance/templates/appearance/generic_list_items_dropdown_subtemplate.html
+++ b/mayan/apps/appearance/templates/appearance/generic_list_items_dropdown_subtemplate.html
@@ -41,7 +41,7 @@
                                                     <select>
                                                         <option value="" selected>Please select a Reviewer</option>
                                                         {% for user in users %}
-                                                        <option value="{{ user.name }}">{{ user.name }}</option>
+                                                        <option value="{{ user.username }}">{{ user.username }}</option>
                                                         {% endfor %}
                                                     </select>
                                                 </span>

--- a/mayan/apps/common/views.py
+++ b/mayan/apps/common/views.py
@@ -112,7 +112,7 @@ class SetupListView(SimpleView):
 
 
 class ToolsListView(SimpleView):
-    template_name = 'appearance/generic_list_horizontal.html'
+    template_name = 'appearance/horizontal.html'
 
     def get_extra_context(self):
         return {

--- a/mayan/apps/documents/views/reviewer_management_views.py
+++ b/mayan/apps/documents/views/reviewer_management_views.py
@@ -2,10 +2,11 @@ import logging
 
 from django.contrib import messages
 from django.utils.translation import ugettext_lazy as _
+from django.contrib.auth import get_user_model
 
 from mayan.apps.common.classes import ModelQueryFields
 from mayan.apps.views.generics import SingleObjectDropdownListView
-
+from mayan.apps.user_management.api_views import APIUserListView
 from ..icons import icon_document_list
 from ..models.document_models import Document
 from ..permissions import permission_document_view
@@ -33,7 +34,8 @@ class ReviewerManagementView(SingleObjectDropdownListView):
             self.object_list = Document.valid.none()
             context = super().get_context_data(**kwargs)
             
-        # context['users'] = ADD API CALL FOR LIST OF USERS HERE
+        context['users'] = get_user_model().objects
+
         return context
 
     def get_document_queryset(self):

--- a/mayan/apps/documents/views/reviewer_management_views.py
+++ b/mayan/apps/documents/views/reviewer_management_views.py
@@ -34,7 +34,7 @@ class ReviewerManagementView(SingleObjectDropdownListView):
             self.object_list = Document.valid.none()
             context = super().get_context_data(**kwargs)
             
-        context['users'] = get_user_model().objects
+        context['users'] = list(get_user_model().objects.all())
 
         return context
 


### PR DESCRIPTION
Resolves #14 

**Description**
Populated reviewer assignment page's drop-down list with all existing users.

**Code Changes**
See [Files changed](https://github.com/CMU-313/fall-2021-hw2-crabs-adjust-humidity/pull/20/files#diff-d5a9f79375085736d0f21e6fb7e239980611096fa784b1680fe01a7c2c8a89d0) for details.

- In generic_list_items_dropdown_subtemplate.html change preset reference name to real model attribute name. 
adjust base.css for sake of displaying. 

- In views.py, adjust template used for ToolsList. 
- In reviewer_management_views.py, include necessary references and finish up api calls.

**Testing**
Tested with creation of new users.
testing steps: 
1. create new users
2. refresh and see if the user's username is added to the dropdown list

**Dependencies**
Depend on PR #18 for dropdown list html template