### PR TITLE
improve dropdown in reviewer assignment

### DIFF
--- a/mayan/apps/appearance/templates/appearance/generic_list_items_dropdown_subtemplate.html
+++ b/mayan/apps/appearance/templates/appearance/generic_list_items_dropdown_subtemplate.html
@@ -39,7 +39,7 @@
                                                         {{ column_value }}
                                                     {% endif %}
                                                     <select>
-                                                        <option value="" selected>Please select a Reviewer</option>
+                                                        <option value="" selected>Select a reviewer.</option>
                                                         {% for user in users %}
                                                         <option value="{{ user.username }}" style="color: black">{{ user.username }}</option>
                                                         {% endfor %}

--- a/mayan/apps/documents/views/reviewer_management_views.py
+++ b/mayan/apps/documents/views/reviewer_management_views.py
@@ -34,8 +34,8 @@ class ReviewerManagementView(SingleObjectDropdownListView):
             self.object_list = Document.valid.none()
             context = super().get_context_data(**kwargs)
             
-        context['users'] = list(get_user_model().objects.all())
-
+        context['users'] = list(get_user_model().objects.filter(is_superuser=False, is_staff=False).order_by('username'))
+        #get all user that is not admin, and order them by username
         return context
 
     def get_document_queryset(self):


### PR DESCRIPTION
**Description** 
This PR adds additional filters to the user object list being pulled for rendering on the frontend. Specifically, it only includes **non** super-users and orders the users alphabetically by username. This change will make the frontend is more intuitive for the assigner since searching down the now alphabetical list for a specific name will become easier.

**Testing**
This PR was manually tested by creating arbitrary users and confirming that they were rendered in alphabetical order. Additionally, superusers were added and they did not show up in the options, as intended. 