### PR TITLE
Added support for multiple reviewer selection and removed unnecessary navigation

### DIFF
--- a/mayan/apps/appearance/templates/appearance/generic_list_items_dropdown_subtemplate.html
+++ b/mayan/apps/appearance/templates/appearance/generic_list_items_dropdown_subtemplate.html
@@ -24,21 +24,10 @@
                                             <label for="id_indexes_0" style="cursor: auto;">
                                                 {% if links_multi_menus_results and not hide_multi_item_actions %}
                                                     <input class="form-multi-object-action-checkbox check-all-slave checkbox" name="pk_{{ object.pk }}" style="cursor: pointer;" type="checkbox" />
-                                                {% endif %}
-
+                                                {% endif %}                                              
                                                 <span style="color: white; word-break: break-all; overflow-wrap: break-word;">
-                                                    {% if not hide_object %}
-                                                        {% if not hide_link %}
-                                                            <a href="{{ object.get_absolute_url }}">{{ object }}</a>
-                                                        {% else %}
-                                                            {{ object }}
-                                                        {% endif %}
-                                                    {% else %}
-                                                        {% navigation_get_source_columns source=object only_identifier=True as source_column %}
-                                                        {% navigation_source_column_resolve column=source_column as column_value %}
-                                                        {{ column_value }}
-                                                    {% endif %}
-                                                    <select>
+                                                    
+                                                    <select multiple>
                                                         <option value="" selected>Select a reviewer.</option>
                                                         {% for user in users %}
                                                         <option value="{{ user.username }}" style="color: black">{{ user.username }}</option>

--- a/mayan/apps/documents/views/reviewer_management_views.py
+++ b/mayan/apps/documents/views/reviewer_management_views.py
@@ -6,7 +6,6 @@ from django.contrib.auth import get_user_model
 
 from mayan.apps.common.classes import ModelQueryFields
 from mayan.apps.views.generics import SingleObjectDropdownListView
-from mayan.apps.user_management.api_views import APIUserListView
 from ..icons import icon_document_list
 from ..models.document_models import Document
 from ..permissions import permission_document_view
@@ -34,8 +33,10 @@ class ReviewerManagementView(SingleObjectDropdownListView):
             self.object_list = Document.valid.none()
             context = super().get_context_data(**kwargs)
             
+        #Get all users that aren't administrators, and order them by username
+        context['hide_multi_item_actions'] = True 
+        #context['hide_link'] = True 
         context['users'] = list(get_user_model().objects.filter(is_superuser=False, is_staff=False).order_by('username'))
-        #get all user that is not admin, and order them by username
         return context
 
     def get_document_queryset(self):


### PR DESCRIPTION
**Description**
This PR adds support for multiple selection in the drop down (so now multiple reviewers are allowed as specified by the requirements). It also removes the link to access all the document's settings. Since this dashboard is only meant for assignment, we decided that reducing the clutter/capabilities of this app would be better, especially since there is an overlap in the functionality. So, this PR improves the overall usability of the app.

**Testing**
I have made sure that the intended changes are visible by uploading documents, adding multiple users, and manually checking the changes. 