### PR TITLE
Added ability to assign, manage, and delete reviewers for documents w…

### DIFF
--- a/mayan/apps/documents/apps.py
+++ b/mayan/apps/documents/apps.py
@@ -37,7 +37,7 @@ from .dashboard_widgets import (
     DashboardWidgetDocumentFilePagesTotal, DashboardWidgetDocumentsInTrash,
     DashboardWidgetDocumentsNewThisMonth,
     DashboardWidgetDocumentsPagesNewThisMonth, DashboardWidgetDocumentsTotal,
-    DashboardWidgetDocumentsTypesTotal, DashboardWidgetReviewerManagement,
+    DashboardWidgetDocumentsTypesTotal, DashboardWidgetReviewerAssignment,
 )
 
 # Documents
@@ -82,7 +82,7 @@ from .links.document_links import (
     link_document_type_change, link_document_properties_edit,
     link_document_list, link_document_recently_accessed_list,
     link_document_recently_created_list, link_document_multiple_type_change,
-    link_document_preview, link_document_properties, link_document_reviewer_management
+    link_document_preview, link_document_properties, link_document_reviewer_assignment
 )
 from .links.document_file_links import (
     link_document_file_delete, link_document_file_delete_multiple,
@@ -693,9 +693,9 @@ class DocumentsApp(MayanAppConfig):
             widget=DashboardWidgetDocumentsPagesNewThisMonth, order=5
         )
 
-        dashboard_main.add_widget(
-            widget=DashboardWidgetReviewerManagement, order=6
-        )
+        # dashboard_main.add_widget(
+        #     widget=DashboardWidgetReviewerAssignment, order=6
+        # )
 
         menu_documents.bind_links(
             links=(
@@ -705,7 +705,8 @@ class DocumentsApp(MayanAppConfig):
             )
         )
 
-        menu_main.bind_links(links=(link_document_reviewer_management, menu_documents,), position=0)
+        menu_main.bind_links(links=(link_document_reviewer_assignment,), position=0)
+        menu_main.bind_links(links=(menu_documents,), position=2)
 
         menu_setup.bind_links(links=(link_document_type_setup,))
 

--- a/mayan/apps/documents/dashboard_widgets.py
+++ b/mayan/apps/documents/dashboard_widgets.py
@@ -41,10 +41,10 @@ class DashboardWidgetDocumentFilePagesTotal(DashboardWidgetNumeric):
         ).count()
         return super().render(request)
 
-class DashboardWidgetReviewerManagement(DashboardWidgetNumeric):
+class DashboardWidgetReviewerAssignment(DashboardWidgetNumeric):
     icon = icon_document_edit
-    label = _('Reviewer Management')
-    link = reverse_lazy(viewname='documents:reviewer_management')
+    label = _('Reviewer Assignment')
+    link = reverse_lazy(viewname='documents:reviewer_assignment')
     link_icon = icon_statistics
 
     def render(self, request):

--- a/mayan/apps/documents/links/document_links.py
+++ b/mayan/apps/documents/links/document_links.py
@@ -21,9 +21,9 @@ link_document_list = Link(
     icon=icon_document_list,
     text=_('All documents'), view='documents:document_list'
 )
-link_document_reviewer_management = Link(
+link_document_reviewer_assignment = Link(
     icon=icon_document_edit,
-    text=_('Reviewer management'), view='documents:reviewer_management'
+    text=_('Reviewer assignment'), view='documents:reviewer_assignment'
 )
 link_document_recently_accessed_list = Link(
     icon=icon_document_recently_accessed_list, text=_('Recently accessed'),

--- a/mayan/apps/documents/urls.py
+++ b/mayan/apps/documents/urls.py
@@ -1,4 +1,4 @@
-from mayan.apps.documents.views.reviewer_management_views import ReviewerManagementView
+from mayan.apps.documents.views.reviewer_assignment_views import ReviewerAssignmentView
 from django.conf.urls import url
 
 from .api_views.document_api_views import (
@@ -445,9 +445,9 @@ urlpatterns_documents = [
         view=DocumentTypeChangeView.as_view()
     ),
     url(
-        regex=r'^documents/reviewer/management/$',
-        name='reviewer_management',
-        view=ReviewerManagementView.as_view()
+        regex=r'^documents/reviewer/assignment/$',
+        name='reviewer_assignment',
+        view=ReviewerAssignmentView.as_view()
     ),
 ]
 

--- a/mayan/apps/documents/views/reviewer_assignment_views.py
+++ b/mayan/apps/documents/views/reviewer_assignment_views.py
@@ -22,12 +22,12 @@ from ..permissions import (
 from .document_version_views import DocumentVersionPreviewView
 
 __all__ = (
-    'ReviewerManagementView'
+    'ReviewerAssignmentView'
 )
 logger = logging.getLogger(name=__name__)
 
 
-class ReviewerManagementView(SingleObjectListView):
+class ReviewerAssignmentView(SingleObjectListView):
     object_permission = permission_document_view
 
     def get_context_data(self, **kwargs):
@@ -59,7 +59,7 @@ class ReviewerManagementView(SingleObjectListView):
                 'permission for any document or document type.'
             ),
             'no_results_title': _('No documents available'),
-            'title': _('Reviewer Management'),
+            'title': _('Reviewer Assignment'),
         }
 
     def get_source_queryset(self):

--- a/mayan/apps/tags/apps.py
+++ b/mayan/apps/tags/apps.py
@@ -27,7 +27,12 @@ from .links import (
     link_document_multiple_tag_multiple_remove,
     link_document_tag_multiple_remove, link_document_tag_multiple_attach, link_tag_create,
     link_tag_delete, link_tag_edit, link_tag_list,
-    link_tag_multiple_delete, link_tag_document_list
+    link_tag_multiple_delete, link_tag_document_list, 
+    link_document_reviewer_list, link_document_multiple_reviewer_multiple_attach,
+    link_document_multiple_reviewer_multiple_remove,
+    link_document_reviewer_multiple_remove, link_document_reviewer_multiple_attach, 
+    link_reviewer_create, link_reviewer_delete, link_reviewer_edit, link_reviewer_list,
+    link_reviewer_multiple_delete, link_reviewer_document_list, 
 )
 from .menus import menu_tags
 from .methods import method_document_get_tags
@@ -153,7 +158,7 @@ class TagsApp(MayanAppConfig):
         source_column_tag_document_count.add_exclude(source=DocumentTag)
 
         menu_facet.bind_links(
-            links=(link_document_tag_list,), sources=(Document,)
+            links=(link_document_reviewer_multiple_remove, link_document_reviewer_list, link_document_tag_list,), sources=(Document,)
         )
 
         menu_list_facet.bind_links(
@@ -169,6 +174,7 @@ class TagsApp(MayanAppConfig):
         )
 
         menu_main.bind_links(links=(menu_tags,), position=98)
+        menu_main.bind_links(links=(link_reviewer_list, link_reviewer_create,), position=1)
 
         menu_multi_item.bind_links(
             links=(

--- a/mayan/apps/tags/forms.py
+++ b/mayan/apps/tags/forms.py
@@ -16,3 +16,15 @@ class TagMultipleSelectionForm(FilteredSelectionForm):
         required = False
         widget_class = TagFormWidget
         widget_attributes = {'class': 'select2-tags'}
+
+class ReviewerMultipleSelectionForm(FilteredSelectionForm):
+    class Media:
+        js = ('tags/js/tags_form.js',)
+
+    class Meta:
+        allow_multiple = True
+        field_name = 'tags'
+        label = _('Reviewers')
+        required = False
+        widget_class = TagFormWidget
+        widget_attributes = {'class': 'select2-tags'}

--- a/mayan/apps/tags/links.py
+++ b/mayan/apps/tags/links.py
@@ -67,3 +67,56 @@ link_tag_document_list = Link(
     args='object.id', icon=icon_tag_document_list,
     text=('Documents'), view='tags:tag_document_list'
 )
+link_document_multiple_reviewer_multiple_attach = Link(
+    icon=icon_document_tag_multiple_attach, text=_('Assign reviewers'),
+    view='tags:multiple_documents_reviewer_attach'
+)
+link_document_multiple_reviewer_multiple_remove = Link(
+    icon=icon_document_tag_multiple_remove, text=_('Remove reviewers'),
+    view='tags:multiple_documents_selection_reviewer_remove'
+)
+link_document_reviewer_list = Link(
+    args='resolved_object.pk', icon=icon_document_tag_list,
+    permissions=(permission_tag_view,), text=_(' Add reviewers'),
+    view='tags:document_reviewer_list'
+)
+link_document_reviewer_multiple_remove = Link(
+    args='object.id', icon=icon_document_tag_multiple_remove,
+    permissions=(permission_tag_remove,), text=_(' Remove reviewers'),
+    view='tags:single_document_multiple_reviewer_remove'
+)
+link_document_reviewer_multiple_attach = Link(
+    args='object.pk', icon=icon_document_tag_multiple_attach,
+    permissions=(permission_tag_attach,), text=_('Assign reviewers'),
+    view='tags:reviewer_attach'
+)
+
+link_reviewer_create = Link(
+    icon=icon_tag_create, permissions=(permission_tag_create,),
+    text=_('Create new reviewer'), view='tags:reviewer_create'
+)
+link_reviewer_delete = Link(
+    args='object.id', icon=icon_tag_delete,
+    permissions=(permission_tag_delete,), tags='dangerous',
+    text=_('Delete'), view='tags:reviewer_delete'
+)
+link_reviewer_edit = Link(
+    args='object.id', icon=icon_tag_edit,
+    permissions=(permission_tag_edit,), text=_('Edit'),
+    view='tags:reviewer_edit'
+)
+link_reviewer_list = Link(
+    condition=get_cascade_condition(
+        app_label='tags', model_name='Tag',
+        object_permission=permission_tag_view,
+    ), icon=icon_tag_list,
+    text=_('Reviewer management'), view='tags:reviewer_list'
+)
+link_reviewer_multiple_delete = Link(
+    icon=icon_tag_delete, permissions=(permission_tag_delete,),
+    text=_('Delete'), view='tags:reviewer_multiple_delete'
+)
+link_reviewer_document_list = Link(
+    args='object.id', icon=icon_tag_document_list,
+    text=('Documents'), view='tags:reviewer_document_list'
+)

--- a/mayan/apps/tags/urls.py
+++ b/mayan/apps/tags/urls.py
@@ -8,7 +8,9 @@ from .api_views import (
 from .views import (
     DocumentTagListView, TagAttachActionView, TagCreateView,
     TagDeleteActionView, TagEditView, TagListView, TagRemoveActionView,
-    TagDocumentListView
+    TagDocumentListView, DocumentReviewerListView, ReviewerAttachActionView,
+    ReviewerCreateView, ReviewerDeleteActionView, ReviewerEditView, ReviewerListView,
+    ReviewerRemoveActionView, ReviewerDocumentListView
 )
 
 urlpatterns = [
@@ -55,6 +57,50 @@ urlpatterns = [
     url(
         regex=r'^tags/multiple/delete/$', name='tag_multiple_delete',
         view=TagDeleteActionView.as_view()
+    ),
+    url(
+        regex=r'^documents/(?P<document_id>\d+)/reviewers/$',
+        name='document_reviewer_list', view=DocumentReviewerListView.as_view()
+    ),
+    url(
+        regex=r'^documents/(?P<document_id>\d+)/reviewers/multiple/attach/$',
+        name='reviewer_attach', view=ReviewerAttachActionView.as_view()
+    ),
+    url(
+        regex=r'^documents/(?P<document_id>\d+)/reviewers/multiple/remove/$',
+        name='single_document_multiple_reviewer_remove',
+        view=ReviewerRemoveActionView.as_view()
+    ),
+    url(
+        regex=r'^documents/multiple/reviewers/multiple/remove/$',
+        name='multiple_documents_selection_reviewer_remove',
+        view=ReviewerRemoveActionView.as_view()
+    ),
+    url(
+        regex=r'^documents/multiple/reviewers/multiple/attach/$',
+        name='multiple_documents_reviewer_attach',
+        view=ReviewerAttachActionView.as_view()
+    ),
+    url(regex=r'^reviewers/$', name='reviewer_list', view=ReviewerListView.as_view()),
+    url(
+        regex=r'^reviewers/create/$', name='reviewer_create',
+        view=ReviewerCreateView.as_view()
+    ),
+    url(
+        regex=r'^reviewers/(?P<tag_id>\d+)/delete/$', name='reviewer_delete',
+        view=ReviewerDeleteActionView.as_view()
+    ),
+    url(
+        regex=r'^reviewers/(?P<tag_id>\d+)/edit/$', name='reviewer_edit',
+        view=ReviewerEditView.as_view()
+    ),
+    url(
+        regex=r'^reviewers/(?P<tag_id>\d+)/documents/$', name='reviewer_document_list',
+        view=ReviewerDocumentListView.as_view()
+    ),
+    url(
+        regex=r'^reviewers/multiple/delete/$', name='reviewer_multiple_delete',
+        view=ReviewerDeleteActionView.as_view()
     )
 ]
 

--- a/mayan/apps/tags/views.py
+++ b/mayan/apps/tags/views.py
@@ -15,9 +15,9 @@ from mayan.apps.views.generics import (
 )
 from mayan.apps.views.mixins import ExternalObjectViewMixin
 
-from .forms import TagMultipleSelectionForm
+from .forms import TagMultipleSelectionForm, ReviewerMultipleSelectionForm
 from .icons import icon_menu_tags, icon_document_tag_remove_submit
-from .links import link_document_tag_multiple_attach, link_tag_create
+from .links import link_document_tag_multiple_attach, link_tag_create, link_document_reviewer_multiple_attach, link_reviewer_create
 from .models import DocumentTag, Tag
 from .permissions import (
     permission_tag_attach, permission_tag_create, permission_tag_delete,
@@ -302,6 +302,296 @@ class TagRemoveActionView(MultipleObjectFormActionView):
         if self.object_list.count() == 1:
             return reverse(
                 viewname='tags:document_tag_list', kwargs={
+                    'document_id': self.object_list.first().pk
+                }
+            )
+        else:
+            return super().get_post_action_redirect()
+
+    def object_action(self, form, instance):
+        for tag in form.cleaned_data['tags']:
+            AccessControlList.objects.check_access(
+                obj=tag, permissions=(permission_tag_remove,),
+                user=self.request.user
+            )
+
+            tag._event_actor = self.request.user
+            tag.remove_from(document=instance)
+
+class ReviewerAttachActionView(MultipleObjectFormActionView):
+    form_class = ReviewerMultipleSelectionForm
+    object_permission = permission_tag_attach
+    pk_url_kwarg = 'document_id'
+    source_queryset = Document.valid
+    success_message_single = _(
+        'Reviewers assigned to document "%(object)s" successfully.'
+    )
+    success_message_singular = _(
+        'Reviewers assigned to %(count)d document successfully.'
+    )
+    success_message_plural = _(
+        'Reviewers assigned to %(count)d documents successfully.'
+    )
+    title_single = _('Assign reviewers to document: %(object)s')
+    title_singular = _('Assign reviewers to %(count)d document.')
+    title_plural = _('Assign reviewers to %(count)d documents.')
+
+    def get_extra_context(self):
+        context = {
+            'submit_label': _('Assign'),
+        }
+
+        if self.object_list.count() == 1:
+            context.update(
+                {
+                    'object': self.object_list.first(),
+                }
+            )
+
+        return context
+
+    def get_form_extra_kwargs(self):
+        kwargs = {
+            'help_text': _('Reviewers to be assigned.'),
+            'permission': permission_tag_attach,
+            'queryset': Tag.objects.all(),
+            'user': self.request.user
+        }
+
+        if self.object_list.count() == 1:
+            kwargs.update(
+                {
+                    'queryset': Tag.objects.exclude(
+                        pk__in=self.object_list.first().tags.all()
+                    )
+                }
+            )
+
+        return kwargs
+
+    def get_post_action_redirect(self):
+        if self.object_list.count() == 1:
+            return reverse(
+                viewname='tags:document_reviewer_list', kwargs={
+                    'document_id': self.object_list.first().pk
+                }
+            )
+        else:
+            return super().get_post_action_redirect()
+
+    def object_action(self, form, instance):
+        for tag in form.cleaned_data['tags']:
+            AccessControlList.objects.check_access(
+                obj=tag, permissions=(permission_tag_attach,),
+                user=self.request.user
+            )
+
+            tag._event_actor = self.request.user
+            tag.attach_to(document=instance)
+
+
+class ReviewerCreateView(SingleObjectCreateView):
+    extra_context = {'title': _('Create reviewer')}
+    fields = ('label', 'color')
+    model = Tag
+    post_action_redirect = reverse_lazy(viewname='tags:reviewer_list')
+    view_permission = permission_tag_create
+
+    def get_instance_extra_data(self):
+        return {
+            '_event_actor': self.request.user
+        }
+
+
+class ReviewerDeleteActionView(MultipleObjectConfirmActionView):
+    error_message = _('Error deleting reviewer "%(instance)s"; %(exception)s')
+    model = Tag
+    object_permission = permission_tag_delete
+    pk_url_kwarg = 'tag_id'
+    post_action_redirect = reverse_lazy(viewname='tags:reviewer_list')
+    success_message_single = _('Reviewer "%(object)s" deleted successfully.')
+    success_message_singular = _('%(count)d reviewer deleted successfully.')
+    success_message_plural = _('%(count)d reviewers deleted successfully.')
+    title_single = _('Delete reviewer: %(object)s.')
+    title_singular = _('Delete the %(count)d selected reviewer.')
+    title_plural = _('Delete the %(count)d selected reviewers.')
+
+    def get_extra_context(self):
+        context = {
+            'delete_view': True,
+            'message': _('Will be removed from all documents.'),
+        }
+
+        if self.object_list.count() == 1:
+            context.update(
+                {
+                    'object': self.object_list.first(),
+                }
+            )
+
+        return context
+
+    def object_action(self, instance, form=None):
+        instance.delete()
+
+
+class ReviewerEditView(SingleObjectEditView):
+    fields = ('label', 'color')
+    model = Tag
+    object_permission = permission_tag_edit
+    pk_url_kwarg = 'tag_id'
+    post_action_redirect = reverse_lazy(viewname='tags:reviewer_list')
+
+    def get_extra_context(self):
+        return {
+            'object': self.object,
+            'title': _('Edit reviewer: %s') % self.object,
+        }
+
+    def get_instance_extra_data(self):
+        return {
+            '_event_actor': self.request.user
+        }
+
+
+class ReviewerListView(SingleObjectListView):
+    object_permission = permission_tag_view
+    tag_model = Tag
+
+    def get_extra_context(self):
+        return {
+            'hide_link': True,
+            'hide_object': True,
+            'no_results_icon': icon_menu_tags,
+            'no_results_main_link': link_reviewer_create.resolve(
+                context=RequestContext(request=self.request)
+            ),
+            'no_results_text': _(
+                'Reviewers can be assigned or removed from documents.'
+            ),
+            'no_results_title': _('No reviewers available'),
+            'title': _('Reviewers'),
+        }
+
+    def get_source_queryset(self):
+        queryset = ModelQueryFields.get(model=self.tag_model).get_queryset()
+        return queryset.filter(pk__in=self.get_tag_queryset())
+
+    def get_tag_queryset(self):
+        return Tag.objects.all()
+
+
+class ReviewerDocumentListView(ExternalObjectViewMixin, DocumentListView):
+    external_object_class = Tag
+    external_object_permission = permission_tag_view
+    external_object_pk_url_kwarg = 'tag_id'
+
+    def get_document_queryset(self):
+        return Document.valid.filter(
+            pk__in=self.get_tag().get_documents(
+                permission=permission_tag_view, user=self.request.user
+            ).values('pk')
+        )
+
+    def get_extra_context(self):
+        context = super().get_extra_context()
+        context.update(
+            {
+                'object': self.get_tag(),
+                'title': _('Documents with the reviewer: %s') % self.get_tag(),
+            }
+        )
+        return context
+
+    def get_tag(self):
+        return self.external_object
+
+
+class DocumentReviewerListView(ExternalObjectViewMixin, ReviewerListView):
+    external_object_permission = permission_tag_view
+    external_object_pk_url_kwarg = 'document_id'
+    external_object_queryset = Document.valid
+    tag_model = DocumentTag
+
+    def get_extra_context(self):
+        context = super().get_extra_context()
+        context.update(
+            {
+                'hide_link': True,
+                'no_results_main_link': link_document_reviewer_multiple_attach.resolve(
+                    context=RequestContext(
+                        self.request, {'object': self.external_object}
+                    )
+                ),
+                'no_results_title': _('Document has no reviewers assigned'),
+                'object': self.external_object,
+                'title': _(
+                    'Reviewers for document: %s'
+                ) % self.external_object,
+            }
+        )
+        return context
+
+    def get_tag_queryset(self):
+        return self.external_object.get_tags(
+            permission=permission_tag_view, user=self.request.user
+        )
+
+
+class ReviewerRemoveActionView(MultipleObjectFormActionView):
+    form_class = ReviewerMultipleSelectionForm
+    object_permission = permission_tag_remove
+    pk_url_kwarg = 'document_id'
+    source_queryset = Document.valid
+    success_message_single = _(
+        'Reviewers removed from document "%(object)s" successfully.'
+    )
+    success_message_singular = _(
+        'Reviewers removed from %(count)d document successfully.'
+    )
+    success_message_plural = _(
+        'Reviewers removed from %(count)d documents successfully.'
+    )
+    title_single = _('Remove reviewers from document: %(object)s')
+    title_singular = _('Remove reviewers from %(count)d document.')
+    title_plural = _('Remove reviewers from %(count)d documents.')
+
+    def get_extra_context(self):
+        context = {
+            'submit_icon': icon_document_tag_remove_submit,
+            'submit_label': _('Remove'),
+        }
+
+        if self.object_list.count() == 1:
+            context.update(
+                {
+                    'object': self.object_list.first(),
+                }
+            )
+
+        return context
+
+    def get_form_extra_kwargs(self):
+        kwargs = {
+            'help_text': _('Reviewers to be removed.'),
+            'permission': permission_tag_remove,
+            'queryset': Tag.objects.all(),
+            'user': self.request.user
+        }
+
+        if self.object_list.count() == 1:
+            kwargs.update(
+                {
+                    'queryset': self.object_list.first().tags.all()
+                }
+            )
+
+        return kwargs
+
+    def get_post_action_redirect(self):
+        if self.object_list.count() == 1:
+            return reverse(
+                viewname='tags:document_reviewer_list', kwargs={
                     'document_id': self.object_list.first().pk
                 }
             )


### PR DESCRIPTION
…ith similar actions as tags

The main menu now has Reviewer management (bringing the user to a list of all reviewers where they can modify or remove reviewers), Reviewer assignment (bringing the user to the page of all documents from which once they select a document, they can choose to either Add reviewer or Remove reviewers from the action menu), and Create new reviewer links (bringing the user to the page where they can create a new reviewer).

When the user assigns a reviewer, the username would thus appear as a tag on the document so they can clearly see which reviewers are associated with each document.